### PR TITLE
Add coinmarketcap feed customisation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules
 npm-debug.log
 .tern-port
+/.vscode

--- a/js/background.js
+++ b/js/background.js
@@ -109,12 +109,8 @@ const populateFeedData = () => {
 };
 
 const parseFeedData = feed => {
-  if (feed) {
-    Object.keys(availableFeeds).forEach(function(item) {
-      if (item === feed) {
-        return getData(availableFeeds[item]);
-      }
-    });
+  if(availableFeeds.hasOwnProperty(feed)) {
+    return getData(availableFeeds[feed]);
   } else {
     storage.sync.set({feed: "lsk"});
     return getData(availableFeeds.lsk);

--- a/js/popup.js
+++ b/js/popup.js
@@ -1,25 +1,45 @@
-const { storage } = chrome;
+const {storage} = chrome;
 
-const form = document.querySelector('.form-group');
+const form = document.querySelector(".js-currencies"),
+  feed = document.querySelector(".js-feed"),
+  buttons = document.querySelector(".buttons");
 
-const updateLabel = name => name === 'BTC' ? 'mBTC' : name;
+const updateLabel = name => (name === "BTC" ? "mBTC" : name);
 
-const renderCurrencies = ({data, select}) => {
-  const selected = select || 'USD';
+const renderCurrencies = ({data, select, feed}) => {
+  const currencySelected = select || "USD";
+  const feedSelected = feed || "lsk";
+  buttons.innerHTML = "";
   Object.keys(data).map(currency => {
-    const label = document.createElement('label');
-    const html = `<input type="radio" name="currency" ${currency === selected && 'checked'} value="${currency}"><i class="form-icon"></i>${updateLabel(currency)}`;
-    label.classList.add('form-radio');
-    label.classList.add('col-6');
+    const label = document.createElement("label");
+    const html = `<input type="radio" name="currency" ${currency ===
+      currencySelected &&
+      "checked"} value="${currency}"><i class="form-icon"></i>${updateLabel(
+      currency
+    )}`;
+    label.classList.add("form-radio");
+    label.classList.add("col-6");
     label.innerHTML = html;
-    form.appendChild(label)
+    buttons.appendChild(label);
+  });
+
+  document.querySelectorAll(".js-feed option").forEach(option => {
+    if (option.value === feed) {
+      option.selected = true;
+    }
   });
 };
 
-form.addEventListener('change', (event) => {
-  storage.sync.set({select: event.target.value });
+feed.addEventListener("change", event => {
+  storage.sync.set({feed: event.target.value});
 });
 
+form.addEventListener("change", event => {
+  storage.sync.set({select: event.target.value});
+});
 
+storage.onChanged.addListener(() => {
+  storage.sync.get(["data", "select", "feed"], renderCurrencies);
+});
 
-storage.sync.get(['data', 'select'], renderCurrencies);
+storage.sync.get(["data", "select", "feed"], renderCurrencies);

--- a/popup.html
+++ b/popup.html
@@ -16,6 +16,13 @@
       <div class="columns">
         <div class="column col-12">
           <div class="form-group">
+            <label class="form-label h5">Select source of truth</label>
+            <select class="js-feed">
+              <option value="cmc">Coinmarketcap</option>
+              <option value="lsk">Lisk</option>
+            </select>
+          </div>
+          <div class="form-group js-currencies">
             <label class="form-label h5">Select currency</label>
             <div class="buttons"></div>
           </div>


### PR DESCRIPTION
Fixes #3 

This adds the coinmarketcap feed as a selectable dropdown. 
Along with dynamic currencies from CMC. Future work would be adding a hardcoded list of CMC currencies but I think it would be too many, there's quite a long list.

## CMC feed
![screen shot 2018-01-09 at 11 51 02](https://user-images.githubusercontent.com/673948/34719656-7e4f9f3a-f533-11e7-872d-28f033136837.png)

## LISK explorer feed
![screen shot 2018-01-09 at 11 51 10](https://user-images.githubusercontent.com/673948/34719673-8c3ca6f6-f533-11e7-8bad-bd81cb72a31a.png)

